### PR TITLE
Added speed control to arbotix_terminal and arbotix_python

### DIFF
--- a/arbotix_msgs/CMakeLists.txt
+++ b/arbotix_msgs/CMakeLists.txt
@@ -12,6 +12,7 @@ add_service_files(FILES
                   Enable.srv
                   Relax.srv
                   SetupChannel.srv
+                  SetSpeed.srv
                  )
 
 generate_messages(DEPENDENCIES std_msgs)

--- a/arbotix_msgs/srv/SetSpeed.srv
+++ b/arbotix_msgs/srv/SetSpeed.srv
@@ -1,0 +1,2 @@
+float64 speed
+---

--- a/arbotix_python/bin/arbotix_terminal
+++ b/arbotix_python/bin/arbotix_terminal
@@ -44,7 +44,7 @@ help = ["ArbotiX Terminal V0.1",
 "",
 "valid parameters",
 " pos - current position of a servo, 0-1023",
-" spd - current speed of a servo, 1-1023",
+" spd - current goal speed of a servo, 0-1023",
 " baud - baud rate",
 " temp - current temperature, degrees C, READ ONLY"]
 
@@ -127,7 +127,7 @@ class Terminal(ArbotiX):
                         else:
                             print self.FAIL+str(value)+self.ENDC
                     elif kmd[1] == "spd" or kmd[1] == "speed":
-                        value = self.getSpeed(int(kmd[2]))
+                        value = self.getGoalSpeed(int(kmd[2]))
                         if value >= 0:
                             print self.OKGREEN+str(value)+self.ENDC
                         else:

--- a/arbotix_python/bin/arbotix_terminal
+++ b/arbotix_python/bin/arbotix_terminal
@@ -44,6 +44,7 @@ help = ["ArbotiX Terminal V0.1",
 "",
 "valid parameters",
 " pos - current position of a servo, 0-1023",
+" spd - current speed of a servo, 1-1023",
 " baud - baud rate",
 " temp - current temperature, degrees C, READ ONLY"]
 
@@ -106,6 +107,9 @@ class Terminal(ArbotiX):
                     elif kmd[1] == "pos" or kmd[1] == "position":
                         self.setPosition( int(kmd[2]), int(kmd[3]) )
                         print self.OKBLUE+"OK"+self.ENDC
+                    elif kmd[1] == "spd" or kmd[1] == "speed":
+                        self.setSpeed( int(kmd[2]), int(kmd[3]) )
+                        print self.OKBLUE+"OK"+self.ENDC
 
                 elif kmd[0] == "get":
                     if kmd[1] == "temp":
@@ -118,6 +122,12 @@ class Terminal(ArbotiX):
                             print self.OKGREEN+str(value)+self.ENDC
                     elif kmd[1] == "pos" or kmd[1] == "position":
                         value = self.getPosition(int(kmd[2]))
+                        if value >= 0:
+                            print self.OKGREEN+str(value)+self.ENDC
+                        else:
+                            print self.FAIL+str(value)+self.ENDC
+                    elif kmd[1] == "spd" or kmd[1] == "speed":
+                        value = self.getSpeed(int(kmd[2]))
                         if value >= 0:
                             print self.OKGREEN+str(value)+self.ENDC
                         else:

--- a/arbotix_python/src/arbotix_python/arbotix.py
+++ b/arbotix_python/src/arbotix_python/arbotix.py
@@ -288,7 +288,7 @@ class ArbotiX:
     def setPosition(self, index, value):
         return self.write(index, P_GOAL_POSITION_L, [value%256, value>>8])
 
-    ## @brief Set the speed of a servo. Don't allow 0 which means "max speed" to a Dynamixel.
+    ## @brief Set the speed of a servo.
     ##
     ## @param index The ID of the device to write.
     ##
@@ -296,7 +296,6 @@ class ArbotiX:
     ##
     ## @return The error level.
     def setSpeed(self, index, value):
-        value = max(1, value)
         return self.write(index, P_GOAL_SPEED_L, [value%256, value>>8])
 
     ## @brief Get the position of a servo.
@@ -318,6 +317,18 @@ class ArbotiX:
     ## @return The servo speed.
     def getSpeed(self, index):
         values = self.read(index, P_PRESENT_SPEED_L, 2)
+        try:
+            return int(values[0]) + (int(values[1])<<8)
+        except:
+            return -1
+        
+    ## @brief Get the goal speed of a servo.
+    ##
+    ## @param index The ID of the device to read.
+    ##
+    ## @return The servo goal speed.
+    def getGoalSpeed(self, index):
+        values = self.read(index, P_GOAL_SPEED_L, 2)
         try:
             return int(values[0]) + (int(values[1])<<8)
         except:

--- a/arbotix_python/src/arbotix_python/arbotix.py
+++ b/arbotix_python/src/arbotix_python/arbotix.py
@@ -288,7 +288,7 @@ class ArbotiX:
     def setPosition(self, index, value):
         return self.write(index, P_GOAL_POSITION_L, [value%256, value>>8])
 
-    ## @brief Set the speed of a servo.
+    ## @brief Set the speed of a servo. Don't allow 0 which means "max speed" to a Dynamixel.
     ##
     ## @param index The ID of the device to write.
     ##
@@ -296,6 +296,7 @@ class ArbotiX:
     ##
     ## @return The error level.
     def setSpeed(self, index, value):
+        value = max(1, value)
         return self.write(index, P_GOAL_SPEED_L, [value%256, value>>8])
 
     ## @brief Get the position of a servo.
@@ -305,6 +306,18 @@ class ArbotiX:
     ## @return The servo position.
     def getPosition(self, index):
         values = self.read(index, P_PRESENT_POSITION_L, 2)
+        try:
+            return int(values[0]) + (int(values[1])<<8)
+        except:
+            return -1
+
+    ## @brief Get the speed of a servo.
+    ##
+    ## @param index The ID of the device to read.
+    ##
+    ## @return The servo speed.
+    def getSpeed(self, index):
+        values = self.read(index, P_PRESENT_SPEED_L, 2)
         try:
             return int(values[0]) + (int(values[1])<<8)
         except:

--- a/arbotix_python/src/arbotix_python/servo_controller.py
+++ b/arbotix_python/src/arbotix_python/servo_controller.py
@@ -86,6 +86,8 @@ class DynamixelServo(Joint):
         rospy.Subscriber(name+'/command', Float64, self.commandCb)
         rospy.Service(name+'/relax', Relax, self.relaxCb)
         rospy.Service(name+'/enable', Enable, self.enableCb)
+        rospy.Service(name+'/set_speed', SetSpeed, self.setSpeedCb)
+
 
     def interpolate(self, frame):
         """ Get the new position to move to, in ticks. """
@@ -189,7 +191,16 @@ class DynamixelServo(Joint):
         angle = (ticks - self.neutral) * self.rad_per_tick
         if self.invert:
             angle = -1.0 * angle
-        return angle        
+        return angle
+
+    def radsToTicks(self, rads_per_sec):
+        """ Convert speed in radians per second to ticks, applying limits. """
+        ticks = self.ticks * rads_per_sec / self.max_speed
+        if ticks >= self.ticks:
+            return self.ticks-1.0
+        if ticks < 0:
+            return 0
+        return ticks  
 
     def enableCb(self, req):
         """ Turn on/off servo torque, so that it is pose-able. """
@@ -221,6 +232,15 @@ class DynamixelServo(Joint):
                 self.dirty = True
                 self.active = True
                 self.desired = req.data
+                
+    def setSpeedCb(self, req):
+        """ Set servo speed. Requested speed is in radians per second. """
+        if not self.device.fake:
+            ticks_per_sec = int(self.radsToTicks(req.speed))
+            self.device.setSpeed(self.id, ticks_per_sec)
+        self.dirty = False
+        self.active = False
+        return SetSpeedResponse()
 
 class HobbyServo(Joint):
 

--- a/arbotix_python/src/arbotix_python/servo_controller.py
+++ b/arbotix_python/src/arbotix_python/servo_controller.py
@@ -193,7 +193,7 @@ class DynamixelServo(Joint):
             angle = -1.0 * angle
         return angle
 
-    def radsToTicks(self, rads_per_sec):
+    def speedToTicks(self, rads_per_sec):
         """ Convert speed in radians per second to ticks, applying limits. """
         ticks = self.ticks * rads_per_sec / self.max_speed
         if ticks >= self.ticks:
@@ -234,12 +234,11 @@ class DynamixelServo(Joint):
                 self.desired = req.data
                 
     def setSpeedCb(self, req):
-        """ Set servo speed. Requested speed is in radians per second. """
+        """ Set servo speed. Requested speed is in radians per second.
+            Don't allow 0 which means "max speed" to a Dynamixel in joint mode. """
         if not self.device.fake:
-            ticks_per_sec = int(self.radsToTicks(req.speed))
+            ticks_per_sec = max(1, int(self.speedToTicks(req.speed)))
             self.device.setSpeed(self.id, ticks_per_sec)
-        self.dirty = False
-        self.active = False
         return SetSpeedResponse()
 
 class HobbyServo(Joint):


### PR DESCRIPTION
I'm hoping to use arbotix_ros instead of dynamixel_conrollers in "Volume 2" of RBX but I need speed control to make this work.  I've tested the changes with both a USB2Dynamixel and an Arbotix using both AX12 and RX24F servos.  It holds up well with real time face tracking with a pan-and-tilt head.

The first commit places a lower limit of 1 instead of 0 on the value of servo speed so that users don't actually move the servo at max speed when they actually meant to stop it.

The second commit adds a 'set spd' option to arbotix_terminal.

The third commit adds a set_speed service to each servo_controller.
