### PR TITLE
Add queue_size=5 parameter to all publishers to avoid the WARN on Indigo

### DIFF
--- a/arbotix_controllers/bin/gripper_controller
+++ b/arbotix_controllers/bin/gripper_controller
@@ -55,8 +55,8 @@ class TrapezoidGripperModel:
         self.right_joint = rospy.get_param('~joint_right', 'r_gripper_joint')
 
         # publishers
-        self.l_pub = rospy.Publisher(self.left_joint+'/command', Float64)
-        self.r_pub = rospy.Publisher(self.right_joint+'/command', Float64)
+        self.l_pub = rospy.Publisher(self.left_joint+'/command', Float64, queue_size=5)
+        self.r_pub = rospy.Publisher(self.right_joint+'/command', Float64, queue_size=5)
 
     def setCommand(self, command):
         # check limits
@@ -104,7 +104,7 @@ class ParallelGripperModel:
         self.joint = rospy.get_param('~joint', 'gripper_joint')
 
         # publishers
-        self.pub = rospy.Publisher(self.joint+'/command', Float64)
+        self.pub = rospy.Publisher(self.joint+'/command', Float64, queue_size=5)
 
     def setCommand(self, command):
         self.pub.publish((command.position * self.scale) + self.center)
@@ -129,7 +129,7 @@ class OneSideGripperModel:
         self.joint = rospy.get_param('~joint', 'gripper_joint')
 
         # publishers
-        self.pub = rospy.Publisher(self.joint+'/command', Float64)
+        self.pub = rospy.Publisher(self.joint+'/command', Float64, queue_size=5)
 
     def setCommand(self, command):
         """ Take an input command of width to open gripper. """

--- a/arbotix_controllers/bin/gripper_controller.py
+++ b/arbotix_controllers/bin/gripper_controller.py
@@ -55,8 +55,8 @@ class TrapezoidGripperModel:
         self.right_joint = rospy.get_param('~joint_right', 'r_gripper_joint')
 
         # publishers
-        self.l_pub = rospy.Publisher(self.left_joint+'/command', Float64)
-        self.r_pub = rospy.Publisher(self.right_joint+'/command', Float64)
+        self.l_pub = rospy.Publisher(self.left_joint+'/command', Float64, queue_size=5)
+        self.r_pub = rospy.Publisher(self.right_joint+'/command', Float64, queue_size=5)
 
     def setCommand(self, command):
         # check limits
@@ -104,7 +104,7 @@ class ParallelGripperModel:
         self.joint = rospy.get_param('~joint', 'gripper_joint')
 
         # publishers
-        self.pub = rospy.Publisher(self.joint+'/command', Float64)
+        self.pub = rospy.Publisher(self.joint+'/command', Float64, queue_size=5)
 
     def setCommand(self, command):
         self.pub.publish((command.position * self.scale) + self.center)
@@ -129,7 +129,7 @@ class OneSideGripperModel:
         self.joint = rospy.get_param('~joint', 'gripper_joint')
 
         # publishers
-        self.pub = rospy.Publisher(self.joint+'/command', Float64)
+        self.pub = rospy.Publisher(self.joint+'/command', Float64, queue_size=5)
 
     def setCommand(self, command):
         """ Take an input command of width to open gripper. """

--- a/arbotix_controllers/bin/one_side_gripper_controller.py
+++ b/arbotix_controllers/bin/one_side_gripper_controller.py
@@ -47,7 +47,7 @@ class OneSideGripperController:
         self.invert = rospy.get_param("~invert", False)
 
         # publishers
-        self.pub = rospy.Publisher("gripper_joint/command", Float64)
+        self.pub = rospy.Publisher("gripper_joint/command", Float64, queue_size=5)
 
         # subscribe to command and then spin
         rospy.Subscriber("~command", Float64, self.commandCb)

--- a/arbotix_controllers/bin/parallel_gripper_action_controller.py
+++ b/arbotix_controllers/bin/parallel_gripper_action_controller.py
@@ -55,8 +55,8 @@ class ParallelGripperActionController:
         self.invert_r = rospy.get_param('~invert_right', False)
 
         # publishers
-        self.l_pub = rospy.Publisher('l_gripper_joint/command', Float64)
-        self.r_pub = rospy.Publisher('r_gripper_joint/command', Float64)
+        self.l_pub = rospy.Publisher('l_gripper_joint/command', Float64, queue_size=5)
+        self.r_pub = rospy.Publisher('r_gripper_joint/command', Float64, queue_size=5)
 
         # subscribe to command and then spin
         self.server = actionlib.SimpleActionServer('~gripper_action', GripperCommandAction, execute_cb=self.actionCb, auto_start=False)

--- a/arbotix_controllers/bin/parallel_gripper_controller.py
+++ b/arbotix_controllers/bin/parallel_gripper_controller.py
@@ -55,8 +55,8 @@ class ParallelGripperController:
         self.invert_r = rospy.get_param("~invert_right", False)
 
         # publishers
-        self.l_pub = rospy.Publisher("l_gripper_joint/command", Float64)
-        self.r_pub = rospy.Publisher("r_gripper_joint/command", Float64)
+        self.l_pub = rospy.Publisher("l_gripper_joint/command", Float64, queue_size=5)
+        self.r_pub = rospy.Publisher("r_gripper_joint/command", Float64, queue_size=5)
 
         # subscribe to command and then spin
         rospy.Subscriber("~command", Float64, self.commandCb)

--- a/arbotix_controllers/bin/parallel_single_servo_controller.py
+++ b/arbotix_controllers/bin/parallel_single_servo_controller.py
@@ -51,7 +51,7 @@ class ParallelGripperController:
         self.invert = rospy.get_param("~invert", False)
         
         # publishers
-        self.commandPub = rospy.Publisher("gripper_joint/command", Float64)
+        self.commandPub = rospy.Publisher("gripper_joint/command", Float64, queue_size=5)
         self.br = tf.TransformBroadcaster()
     
         # current width of gripper

--- a/arbotix_python/bin/arbotix_gui
+++ b/arbotix_python/bin/arbotix_gui
@@ -78,7 +78,7 @@ class controllerGUI(wx.Frame):
         self.turn = 0
         self.X = 0
         self.Y = 0
-        self.cmd_vel = rospy.Publisher('cmd_vel', Twist)
+        self.cmd_vel = rospy.Publisher('cmd_vel', Twist, queue_size=5)
 
         # Move Servos
         servo = wx.StaticBox(self, -1, 'Move Servos')
@@ -100,7 +100,7 @@ class controllerGUI(wx.Frame):
             # pull angles
             min_angle, max_angle = getJointLimits(name, joint_defaults)
             # create publisher
-            self.publishers.append(rospy.Publisher(name+'/command', Float64))
+            self.publishers.append(rospy.Publisher(name+'/command', Float64, queue_size=5))
             if rospy.get_param('/arbotix/joints/'+name+'/type','dynamixel') == 'dynamixel':
                 self.relaxers.append(rospy.ServiceProxy(name+'/relax', Relax))
             else:

--- a/arbotix_python/src/arbotix_python/diff_controller.py
+++ b/arbotix_python/src/arbotix_python/diff_controller.py
@@ -91,7 +91,7 @@ class DiffController(Controller):
 
         # subscriptions
         rospy.Subscriber("cmd_vel", Twist, self.cmdVelCb)
-        self.odomPub = rospy.Publisher("odom",Odometry)
+        self.odomPub = rospy.Publisher("odom", Odometry, queue_size=5)
         self.odomBroadcaster = TransformBroadcaster()
 		
         rospy.loginfo("Started DiffController ("+name+"). Geometry: " + str(self.base_width) + "m wide, " + str(self.ticks_meter) + " ticks/m.")

--- a/arbotix_python/src/arbotix_python/io.py
+++ b/arbotix_python/src/arbotix_python/io.py
@@ -55,7 +55,7 @@ class DigitalSensor:
         self.device = device
         self.pin = pin
         self.device.setDigital(pin, value, 0)
-        self.pub = rospy.Publisher('~'+name, Digital)
+        self.pub = rospy.Publisher('~'+name, Digital, queue_size=5)
         self.t_delta = rospy.Duration(1.0/rate)
         self.t_next = rospy.Time.now() + self.t_delta
     def update(self):
@@ -72,7 +72,7 @@ class AnalogSensor:
         self.device = device
         self.pin = pin
         self.device.setDigital(pin, value, 0)
-        self.pub = rospy.Publisher('~'+name, Analog)
+        self.pub = rospy.Publisher('~'+name, Analog, queue_size=5)
         self.t_delta = rospy.Duration(1.0/rate)
         self.t_next = rospy.Time.now() + self.t_delta
     def update(self):

--- a/arbotix_python/src/arbotix_python/publishers.py
+++ b/arbotix_python/src/arbotix_python/publishers.py
@@ -37,7 +37,7 @@ class DiagnosticsPublisher:
     def __init__(self):
         self.t_delta = rospy.Duration(1.0/rospy.get_param("~diagnostic_rate", 1.0))
         self.t_next = rospy.Time.now() + self.t_delta
-        self.pub = rospy.Publisher('diagnostics', DiagnosticArray)
+        self.pub = rospy.Publisher('diagnostics', DiagnosticArray, queue_size=5)
 
     def update(self, joints, controllers):
         """ Publish diagnostics. """    
@@ -69,7 +69,7 @@ class JointStatePublisher:
         self.t_next = rospy.Time.now() + self.t_delta
 
         # subscriber
-        self.pub = rospy.Publisher('joint_states', JointState)
+        self.pub = rospy.Publisher('joint_states', JointState, queue_size=5)
 
     def update(self, joints, controllers):
         """ publish joint states. """

--- a/arbotix_sensors/bin/ir_ranger.py
+++ b/arbotix_sensors/bin/ir_ranger.py
@@ -67,7 +67,7 @@ class ir_ranger:
         self.msg.max_range = self.sensor.max_range
 
         # publish/subscribe
-        self.pub = rospy.Publisher("ir_range", Range)
+        self.pub = rospy.Publisher("ir_range", Range, queue_size=5)
         rospy.Subscriber("arbotix/"+req.topic_name, Analog, self.readingCb)
 
         rospy.spin()

--- a/arbotix_sensors/bin/max_sonar.py
+++ b/arbotix_sensors/bin/max_sonar.py
@@ -60,7 +60,7 @@ class max_sonar:
         self.msg.max_range = self.sensor.max_range
 
         # publish/subscribe
-        self.pub = rospy.Publisher("sonar_range", Range)
+        self.pub = rospy.Publisher("sonar_range", Range, queue_size=5)
         rospy.Subscriber("arbotix/"+req.topic_name, Analog, self.readingCb)
 
         rospy.spin()


### PR DESCRIPTION
SyntaxWarning: The publisher should be created with an explicit keyword
argument 'queue_size'. Please see
http://wiki.ros.org/rospy/Overview/Publishers%20and%20Subscribers for
more information.

@mikeferguson, I add this to hydro-devel as we don't have still an indigo branch, but I have no problem doing otherwise, that is, create an indigo branch and add all oncoming changes there. Up to you!.
