### PR TITLE
roslib.load_manifest should not be used on catkin packages

### DIFF
--- a/arbotix_controllers/bin/one_side_gripper_controller.py
+++ b/arbotix_controllers/bin/one_side_gripper_controller.py
@@ -27,7 +27,6 @@
   ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """
 
-import roslib; roslib.load_manifest('arbotix_controllers')
 import rospy
 import thread
 

--- a/arbotix_controllers/bin/parallel_gripper_controller.py
+++ b/arbotix_controllers/bin/parallel_gripper_controller.py
@@ -27,7 +27,6 @@
   ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """
 
-import roslib; roslib.load_manifest('arbotix_controllers')
 import rospy
 import thread
 

--- a/arbotix_controllers/bin/parallel_single_servo_controller.py
+++ b/arbotix_controllers/bin/parallel_single_servo_controller.py
@@ -27,7 +27,6 @@
   ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """
 
-import roslib; roslib.load_manifest('arbotix_controllers')
 import rospy, tf
 import thread
 

--- a/arbotix_sensors/bin/ir_ranger.py
+++ b/arbotix_sensors/bin/ir_ranger.py
@@ -27,7 +27,6 @@
   ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """
 
-import roslib; roslib.load_manifest('arbotix_sensors')
 import rospy
 
 from sensor_msgs.msg import Range

--- a/arbotix_sensors/bin/max_sonar.py
+++ b/arbotix_sensors/bin/max_sonar.py
@@ -27,7 +27,6 @@
   ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """
 
-import roslib; roslib.load_manifest('arbotix_sensors')
 import rospy
 
 from sensor_msgs.msg import Range


### PR DESCRIPTION
According to http://wiki.ros.org/PyStyleGuide
