### PR TITLE
Implement issue https://github.com/vanadiumlabs/arbotix_ros/issues/24:

### DIFF
--- a/arbotix_msgs/msg/Analog.msg
+++ b/arbotix_msgs/msg/Analog.msg
@@ -1,3 +1,3 @@
 # Reading from a single analog IO pin.
 Header header
-uint8 value
+uint16 value

--- a/arbotix_python/bin/arbotix_driver
+++ b/arbotix_python/bin/arbotix_driver
@@ -128,7 +128,8 @@ class ArbotixROS(ArbotiX):
                     pin = rospy.get_param('~'+v+'/'+name+'/pin',1)
                     value = rospy.get_param('~'+v+'/'+name+'/value',0)
                     rate = rospy.get_param('~'+v+'/'+name+'/rate',10)
-                    self.io[name] = t(name, pin, value, rate, self)
+                    leng = rospy.get_param('~'+v+'/'+name+'/leng',1)  # just for analog sensors
+                    self.io[name] = t(name, pin, value, rate, leng, self)
         
         r = rospy.Rate(self.rate)
 
@@ -156,7 +157,7 @@ class ArbotixROS(ArbotiX):
     def analogInCb(self, req):
         # TODO: Add check, only 1 service per pin
         if not self.fake:
-            self.io[req.topic_name] = AnalogSensor(req.topic_name, req.pin, req.value, req.rate, self) 
+            self.io[req.topic_name] = AnalogSensor(req.topic_name, req.pin, req.value, req.rate, req.leng, self)
         return SetupChannelResponse()
 
     def digitalInCb(self, req):

--- a/arbotix_python/bin/arbotix_driver
+++ b/arbotix_python/bin/arbotix_driver
@@ -128,7 +128,7 @@ class ArbotixROS(ArbotiX):
                     pin = rospy.get_param('~'+v+'/'+name+'/pin',1)
                     value = rospy.get_param('~'+v+'/'+name+'/value',0)
                     rate = rospy.get_param('~'+v+'/'+name+'/rate',10)
-                    leng = rospy.get_param('~'+v+'/'+name+'/leng',1)  # just for analog sensors
+                    leng = rospy.get_param('~'+v+'/'+name+'/length',1)  # just for analog sensors
                     self.io[name] = t(name, pin, value, rate, leng, self)
         
         r = rospy.Rate(self.rate)

--- a/arbotix_python/src/arbotix_python/arbotix.py
+++ b/arbotix_python/src/arbotix_python/arbotix.py
@@ -450,10 +450,13 @@ class ArbotiX:
     ##
     ## @param index The ID of the pin to read (0 to 7).
     ##
-    ## @return 8-bit analog value of the pin, -1 if error.
-    def getAnalog(self, index):
+    ## @param leng The number of bytes to read (1 or 2).
+    ##
+    ## @return 8-bit/16-bit analog value of the pin, -1 if error.
+    def getAnalog(self, index, leng=1):
         try:
-            return int(self.read(253, self.ANA_BASE+int(index), 1)[0])
+            val = self.read(253, self.ANA_BASE+int(index), leng)
+            return sum(val[i] << (i * 8) for i in range(leng))
         except:
             return -1
 

--- a/arbotix_python/src/arbotix_python/io.py
+++ b/arbotix_python/src/arbotix_python/io.py
@@ -68,18 +68,20 @@ class DigitalSensor:
 
 class AnalogSensor:
     """ Class for an analog input. """
-    def __init__(self, name, pin, value, rate, device):
+    def __init__(self, name, pin, value, rate, leng, device):
         self.device = device
         self.pin = pin
         self.device.setDigital(pin, value, 0)
         self.pub = rospy.Publisher('~'+name, Analog, queue_size=5)
         self.t_delta = rospy.Duration(1.0/rate)
         self.t_next = rospy.Time.now() + self.t_delta
+        self.leng = leng
     def update(self):
         if rospy.Time.now() > self.t_next:
             msg = Analog()
             msg.header.stamp = rospy.Time.now()
-            msg.value = self.device.getAnalog(self.pin)
-            self.pub.publish(msg)
+            msg.value = self.device.getAnalog(self.pin, self.leng)
+            if msg.value >= 0:
+                self.pub.publish(msg)
             self.t_next = rospy.Time.now() + self.t_delta
 


### PR DESCRIPTION
Allow 16 bit values on arbotix_msgs/Analog messages, but assume 8 bits by default. So changes should be transparent for current users except for the extra size of message value.
