### PR TITLE
Trajectory FollowController: Support individual (async) joint velocities

### DIFF
--- a/arbotix_python/src/arbotix_python/follow_controller.py
+++ b/arbotix_python/src/arbotix_python/follow_controller.py
@@ -149,7 +149,7 @@ class FollowController(Controller):
                 velocity = [ abs(point.velocities[k]) for k in indexes ]
                 err = [ (d-c) for d,c in zip(desired,last) ]
                                     
-                if not all(v > 0  for e,v in zip(err,velocity) if e!=0):
+                if not all(v > 0  for e,v in zip(err,velocity) if e < -0.001 or e > 0.001):
                     rospy.logerr("Specifying a nonzero joint transition with zero velocity is not possible. Cannot proceed.")
                     return -1
                 # get maximum required endtime w.r.t. the slowest transition

--- a/arbotix_python/src/arbotix_python/follow_controller.py
+++ b/arbotix_python/src/arbotix_python/follow_controller.py
@@ -90,12 +90,17 @@ class FollowController(Controller):
             self.server.set_aborted(text=msg)
             return
 
-        if self.executeTrajectory(traj):   
+        retval = self.executeTrajectory(traj) # 1: successful, 0: canceled, -1: failed
+        if retval == 1:   
             self.server.set_succeeded()
+            rospy.loginfo(self.name + ": Done.")
+        elif retval == 0 :
+ 	    self.server.set_preempted(text="Goal canceled.")     
+ 	    rospy.loginfo(self.name + ": Goal canceled.")
         else:
-            self.server.set_aborted(text="Execution failed.")
-
-        rospy.loginfo(self.name + ": Done.")
+	    self.server.set_aborted(text="Execution failed.")
+	    rospy.loginfo(self.name + ": Execution failed.")
+ 
     
     def commandCb(self, msg):
         # don't execute if executing an action
@@ -114,7 +119,7 @@ class FollowController(Controller):
             indexes = [traj.joint_names.index(joint) for joint in self.joints]
         except ValueError as val:
             rospy.logerr("Invalid joint in trajectory.")
-            return False
+            return -1
 
         # get starting timestamp, MoveIt uses 0, need to fill in
         start = traj.header.stamp
@@ -125,10 +130,17 @@ class FollowController(Controller):
         last = [ self.device.joints[joint].position for joint in self.joints ]
         for point in traj.points:
             while rospy.Time.now() + rospy.Duration(0.01) < start:
+	      	if self.server.is_preempt_requested():
+		  return 0
                 rospy.sleep(0.01)
             desired = [ point.positions[k] for k in indexes ]
             endtime = start + point.time_from_start
             while rospy.Time.now() + rospy.Duration(0.01) < endtime:
+	      
+		# check that preempt has not been requested by the client
+		if self.server.is_preempt_requested():
+		  return 0
+
                 err = [ (d-c) for d,c in zip(desired,last) ]
                 velocity = [ abs(x / (self.rate * (endtime - rospy.Time.now()).to_sec())) for x in err ]
                 rospy.logdebug(err)
@@ -145,7 +157,7 @@ class FollowController(Controller):
                     else:
                         velocity[i] = 0
                 r.sleep()
-        return True
+        return 1
 
     def active(self):
         """ Is controller overriding servo internal control? """

--- a/arbotix_python/src/arbotix_python/follow_controller.py
+++ b/arbotix_python/src/arbotix_python/follow_controller.py
@@ -90,16 +90,16 @@ class FollowController(Controller):
             self.server.set_aborted(text=msg)
             return
 
-        retval = self.executeTrajectory(traj) # 1: successful, 0: canceled, -1: failed
+        retval = self.executeTrajectory(traj) # retval: 1: successful, 0: canceled, -1: failed
         if retval == 1:   
             self.server.set_succeeded()
             rospy.loginfo(self.name + ": Done.")
-        elif retval == 0 :
- 	    self.server.set_preempted(text="Goal canceled.")     
- 	    rospy.loginfo(self.name + ": Goal canceled.")
+        elif retval == 0:
+           self.server.set_preempted(text="Goal canceled.")     
+           rospy.loginfo(self.name + ": Goal canceled.")
         else:
-	    self.server.set_aborted(text="Execution failed.")
-	    rospy.loginfo(self.name + ": Execution failed.")
+            self.server.set_aborted(text="Execution failed.")
+            rospy.loginfo(self.name + ": Execution failed.")
  
     
     def commandCb(self, msg):
@@ -130,16 +130,15 @@ class FollowController(Controller):
         last = [ self.device.joints[joint].position for joint in self.joints ]
         for point in traj.points:
             while rospy.Time.now() + rospy.Duration(0.01) < start:
-	      	if self.server.is_preempt_requested():
-		  return 0
+                if self.server.is_preempt_requested():
+                    return 0
                 rospy.sleep(0.01)
             desired = [ point.positions[k] for k in indexes ]
             endtime = start + point.time_from_start
             while rospy.Time.now() + rospy.Duration(0.01) < endtime:
-	      
-		# check that preempt has not been requested by the client
-		if self.server.is_preempt_requested():
-		  return 0
+                # check that preempt has not been requested by the client
+                if self.server.is_preempt_requested():
+                    return 0
 
                 err = [ (d-c) for d,c in zip(desired,last) ]
                 velocity = [ abs(x / (self.rate * (endtime - rospy.Time.now()).to_sec())) for x in err ]

--- a/arbotix_python/src/arbotix_python/follow_controller.py
+++ b/arbotix_python/src/arbotix_python/follow_controller.py
@@ -159,12 +159,13 @@ class FollowController(Controller):
                     return 0
 
                 err = [ (d-c) for d,c in zip(desired,last) ]
+                rospy.logdebug(err)
+                
                 if sync_transition:
                     velocity = [ abs(x / (self.rate * (endtime - rospy.Time.now()).to_sec())) for x in err ]
                 else:
                     velocity = [ abs(point.velocities[k])/self.rate for k in indexes ]
                         
-                rospy.logdebug(err)
                 for i in range(len(self.joints)):
                     if err[i] > 0.001 or err[i] < -0.001:
                         cmd = err[i] 
@@ -178,7 +179,6 @@ class FollowController(Controller):
                     else:
                         velocity[i] = 0
                 r.sleep()
-                
         return 1
 
     def active(self):

--- a/arbotix_python/src/arbotix_python/follow_controller.py
+++ b/arbotix_python/src/arbotix_python/follow_controller.py
@@ -139,7 +139,7 @@ class FollowController(Controller):
             if point.time_from_start.secs > 0 or point.time_from_start.nsecs > 0:
                 sync_transition = True
                 if len(point.velocities)>0:
-                    rospy.logwarn("Found both a nonzero time_from_start and individual join velocities. Chosing synchronous transition w.r.t. time_from_start.")
+                    rospy.logwarn("Found both a nonzero time_from_start and individual joint velocities. Chosing synchronous transition w.r.t. time_from_start.")
                 endtime = start + point.time_from_start
             else: # second mode: command user-defined velocity profile until desired position is reached (consider joints separately)
                 sync_transition = False

--- a/arbotix_python/src/arbotix_python/follow_controller.py
+++ b/arbotix_python/src/arbotix_python/follow_controller.py
@@ -95,8 +95,8 @@ class FollowController(Controller):
             self.server.set_succeeded()
             rospy.loginfo(self.name + ": Done.")
         elif retval == 0:
-           self.server.set_preempted(text="Goal canceled.")     
-           rospy.loginfo(self.name + ": Goal canceled.")
+            self.server.set_preempted(text="Goal canceled.")     
+            rospy.loginfo(self.name + ": Goal canceled.")
         else:
             self.server.set_aborted(text="Execution failed.")
             rospy.loginfo(self.name + ": Execution failed.")

--- a/arbotix_python/src/arbotix_python/follow_controller.py
+++ b/arbotix_python/src/arbotix_python/follow_controller.py
@@ -138,6 +138,8 @@ class FollowController(Controller):
             # two modes: First the transition time / total duration is specified that implies joint velocities (synchronous transition)
             if point.time_from_start.secs > 0 or point.time_from_start.nsecs > 0:
                 sync_transition = True
+                if len(point.velocities)>0:
+                    rospy.logwarn("Found both a nonzero time_from_start and individual join velocities. Chosing synchronous transition w.r.t. time_from_start.")
                 endtime = start + point.time_from_start
             else: # second mode: command user-defined velocity profile until desired position is reached (consider joints separately)
                 sync_transition = False


### PR DESCRIPTION
During my experiments with a robot and the arbotix package, especially the follow joint trajectory controller, I've missed the possiblity to define trajectories in which each point-to-point transition is augmented with individual joint velocities rather than executing them synchronously.
Of course it might be possible to construct such a trajectory using an appropriate interpolation.
However, I think that specifying either joint velocities or a total transition time simplyfies the definition of most trajectories. Additionally, the JointTrajectoryPoint message already provides the velocity container.
In the proposed extension, the controller distinguishes between both modes. Either the synchronous motion is selected if the value time_from_start is nonzero, otherwise the velocity vector will be taken into account.

_By the way, the extension easily emulates joint velocity control, if the min/max joint angle limit is selected as a single trajectory point (as goal). Due to the possibility to cancel a currently excecuting action, one can overwrite the previously set commands with new ones (of course this is not real velocity control, but works for those who want a quick solution)_ 
