### PR TITLE
Python3 shebang and python3 rosdep package dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .project
 .cproject
 .pydevproject
+.vscode

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Arbotix Drivers
 
-This repository contains the Arbotix ROS drivers, catkinized, and ready for ROS Groovy and newer.
+This repository contains the Arbotix ROS drivers, catkinized, and ready for ROS Noetic.
 
 ## Changes for Groovy (version 0.8.x)
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,3 @@
 ## Arbotix Drivers
 
 This repository contains the Arbotix ROS drivers, catkinized, and ready for ROS Noetic.
-
-## Changes for Groovy (version 0.8.x)
-
-Several executables are now installed in /opt/ros/groovy/bin allowing you to run them without using rosrun:
- * controllerGUI.py is now arbotix_gui
- * terminal.py is now arbotix_terminal
-
-Other executables have been renamed to alleviate any name collisions:
- * driver.py is now renamed arbotix_driver
-

--- a/arbotix_python/CHANGELOG.rst
+++ b/arbotix_python/CHANGELOG.rst
@@ -2,13 +2,6 @@
 Changelog for package arbotix_python
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-0.11.0 (2020-12-25)
--------------------
-* migrate arbotix_python codebase to work with ROS Noetic
-* common python3-fixes like print, imports, exceptions etc. 
-* update depends in package.xml
-* Contributors: Murat Calis
-
 0.10.0 (2014-07-14)
 -------------------
 * Set queue_size=5 on all publishers

--- a/arbotix_python/CHANGELOG.rst
+++ b/arbotix_python/CHANGELOG.rst
@@ -2,6 +2,13 @@
 Changelog for package arbotix_python
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.11.0 (2020-12-25)
+-------------------
+* migrate arbotix_python codebase to work with ROS Noetic
+* common python3-fixes like print, imports, execptions etc. 
+* update depends in package.xml
+* Contributors: Murat Calis
+
 0.10.0 (2014-07-14)
 -------------------
 * Set queue_size=5 on all publishers

--- a/arbotix_python/CHANGELOG.rst
+++ b/arbotix_python/CHANGELOG.rst
@@ -5,7 +5,7 @@ Changelog for package arbotix_python
 0.11.0 (2020-12-25)
 -------------------
 * migrate arbotix_python codebase to work with ROS Noetic
-* common python3-fixes like print, imports, execptions etc. 
+* common python3-fixes like print, imports, exceptions etc. 
 * update depends in package.xml
 * Contributors: Murat Calis
 

--- a/arbotix_python/CMakeLists.txt
+++ b/arbotix_python/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(arbotix_python)
 
 find_package(catkin REQUIRED)

--- a/arbotix_python/bin/arbotix_driver
+++ b/arbotix_python/bin/arbotix_driver
@@ -129,7 +129,10 @@ class ArbotixROS(ArbotiX):
                     value = rospy.get_param('~'+v+'/'+name+'/value',0)
                     rate = rospy.get_param('~'+v+'/'+name+'/rate',10)
                     leng = rospy.get_param('~'+v+'/'+name+'/length',1)  # just for analog sensors
-                    self.io[name] = t(name, pin, value, rate, leng, self)
+                    if(v != "analog_sensors"):
+                        self.io[name] = t(name, pin, value, rate, self)
+                    else:
+                        self.io[name] = t(name, pin, value, rate, leng, self)
         
         r = rospy.Rate(self.rate)
 

--- a/arbotix_python/bin/arbotix_driver
+++ b/arbotix_python/bin/arbotix_driver
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
   ArbotiX Node: serial connection to an ArbotiX board w/ PyPose/NUKE/ROS

--- a/arbotix_python/bin/arbotix_terminal
+++ b/arbotix_python/bin/arbotix_terminal
@@ -59,31 +59,30 @@ class Terminal(ArbotiX):
     def __init__(self, port = "/dev/ttyUSB0", baud = 115200):
         # start
         ArbotiX.__init__(self, port, baud)  
-        print "ArbotiX Terminal --- Version 0.1"
-        print "Copyright 2011 Vanadium Labs LLC"
+        print("ArbotiX Terminal --- Version 0.1")
+        print("Copyright 2011 Vanadium Labs LLC")
 
         # loop
         while True:
-            print ">> ",
-            kmd = raw_input().split(" ")
+            kmd = input(f">> ").split(" ")
             try:
                 if kmd[0] == "help":        # display help data
                     if len(kmd) > 1:        # for a particular command
                         if kmd[1] == "ls":   
-                            print help[3]
+                            print(help[3])
                         elif kmd[1] == "mv":
-                            print help[4]
+                            print(help[4])
                         elif kmd[1] == "baud":
-                            print help[5]
+                            print(help[5])
                         elif kmd[1] == "get":
-                            print help[6]
+                            print(help[6])
                         elif kmd[1] == "set":   
-                            print help[7]
+                            print(help[7])
                         else:
-                            print "help: unrecognized command"
+                            print("help: unrecognized command")
                     else:
                         for h in help:
-                            print h
+                            print(h)
 
                 elif kmd[0] == "ls":       # list servos
                     self._ser.timeout = 0.25
@@ -94,47 +93,47 @@ class Terminal(ArbotiX):
 
                 elif kmd[0] == "mv":         # rename a servo
                     if self.write( int(kmd[1]), P_ID, [int(kmd[2]),] ) == 0:
-                        print self.OKBLUE+"OK"+self.ENDC
+                        print(self.OKBLUE+"OK"+self.ENDC)
 
                 elif kmd[0] == "baud":      # set bus baud rate
                     self.write(253, P_BAUD_RATE, [self.convertBaud(int(kmd[1]))])
-                    print self.OKBLUE+"OK"+self.ENDC
+                    print(self.OKBLUE+"OK"+self.ENDC)
 
                 elif kmd[0] == "set":
                     if kmd[1] == "baud":
                         self.write( int(kmd[2]), P_BAUD_RATE, [self.convertBaud(int(kmd[3]))] )
-                        print self.OKBLUE+"OK"+self.ENDC
+                        print(self.OKBLUE+"OK"+self.ENDC)
                     elif kmd[1] == "pos" or kmd[1] == "position":
                         self.setPosition( int(kmd[2]), int(kmd[3]) )
-                        print self.OKBLUE+"OK"+self.ENDC
+                        print(self.OKBLUE+"OK"+self.ENDC)
                     elif kmd[1] == "spd" or kmd[1] == "speed":
                         self.setSpeed( int(kmd[2]), int(kmd[3]) )
-                        print self.OKBLUE+"OK"+self.ENDC
+                        print(self.OKBLUE+"OK"+self.ENDC)
 
                 elif kmd[0] == "get":
                     if kmd[1] == "temp":
                         value = self.getTemperature(int(kmd[2]))
                         if value >= 60 or value < 0:
-                            print self.FAIL+str(value)+self.ENDC
+                            print(self.FAIL+str(value)+self.ENDC)
                         elif value > 40:
-                            print self.WARNING+str(value)+self.ENDC
+                            print(self.WARNING+str(value)+self.ENDC)
                         else:
-                            print self.OKGREEN+str(value)+self.ENDC
+                            print(self.OKGREEN+str(value)+self.ENDC)
                     elif kmd[1] == "pos" or kmd[1] == "position":
                         value = self.getPosition(int(kmd[2]))
                         if value >= 0:
-                            print self.OKGREEN+str(value)+self.ENDC
+                            print(self.OKGREEN+str(value)+self.ENDC)
                         else:
-                            print self.FAIL+str(value)+self.ENDC
+                            print(self.FAIL+str(value)+self.ENDC)
                     elif kmd[1] == "spd" or kmd[1] == "speed":
                         value = self.getGoalSpeed(int(kmd[2]))
                         if value >= 0:
-                            print self.OKGREEN+str(value)+self.ENDC
+                            print(self.OKGREEN+str(value)+self.ENDC)
                         else:
-                            print self.FAIL+str(value)+self.ENDC
+                            print(self.FAIL+str(value)+self.ENDC)
         
             except Exception as e:
-                print "error...", e
+                print("error...", e)
 
     def query(self, max_id = 18, baud = 1000000):
         k = 0                   # how many id's have we printed
@@ -142,17 +141,17 @@ class Terminal(ArbotiX):
             if self.getPosition(i+1) != -1:
                 if k > 8:
                     k = 0
-                    print ""
-                print repr(i+1).rjust(4),
+                    print("")
+                print(repr(i+1).rjust(4), end="\t"),
                 k = k + 1
             else:
                 if k > 8:
                     k = 0
-                    print ""
-                print "....",
+                    print("")
+                print(" ....", end="\t")
                 k = k + 1
             sys.stdout.flush()
-        print ""
+        print("")
 
     def convertBaud(self, b):
         if b == 500000:
@@ -184,6 +183,6 @@ if __name__ == "__main__":
         else:
             t = Terminal()
     except KeyboardInterrupt:
-        print "\nExiting..."
+        print("\nExiting...")
 
 

--- a/arbotix_python/package.xml
+++ b/arbotix_python/package.xml
@@ -20,7 +20,7 @@
   <exec_depend>control_msgs</exec_depend>
   <exec_depend>nav_msgs</exec_depend>
   <exec_depend>actionlib</exec_depend>
-  <exec_depend>python-serial</exec_depend>
+  <exec_depend>python3-serial</exec_depend>
 </package>
 
 

--- a/arbotix_python/package.xml
+++ b/arbotix_python/package.xml
@@ -1,6 +1,6 @@
-<package>
+<package format="3">
   <name>arbotix_python</name>
-  <version>0.10.0</version>
+  <version>0.11.0</version>
   <description>
     Bindings and low-level controllers for ArbotiX-powered robots.
   </description>
@@ -11,16 +11,16 @@
   
   <buildtool_depend>catkin</buildtool_depend>
 
-  <run_depend>rospy</run_depend>
-  <run_depend>tf</run_depend>
-  <run_depend>arbotix_msgs</run_depend>
-  <run_depend>sensor_msgs</run_depend>
-  <run_depend>geometry_msgs</run_depend>
-  <run_depend>diagnostic_msgs</run_depend>
-  <run_depend>control_msgs</run_depend>
-  <run_depend>nav_msgs</run_depend>
-  <run_depend>actionlib</run_depend>
-  <run_depend>python-serial</run_depend>
+  <exec_depend>rospy</exec_depend>
+  <exec_depend>tf</exec_depend>
+  <exec_depend>arbotix_msgs</exec_depend>
+  <exec_depend>sensor_msgs</exec_depend>
+  <exec_depend>geometry_msgs</exec_depend>
+  <exec_depend>diagnostic_msgs</exec_depend>
+  <exec_depend>control_msgs</exec_depend>
+  <exec_depend>nav_msgs</exec_depend>
+  <exec_depend>actionlib</exec_depend>
+  <exec_depend>python-serial</exec_depend>
 </package>
 
 

--- a/arbotix_python/package.xml
+++ b/arbotix_python/package.xml
@@ -1,6 +1,6 @@
 <package format="3">
   <name>arbotix_python</name>
-  <version>0.11.0</version>
+  <version>0.10.0</version>
   <description>
     Bindings and low-level controllers for ArbotiX-powered robots.
   </description>

--- a/arbotix_python/setup.py
+++ b/arbotix_python/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from distutils.core import setup
+from setuptools import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 d = generate_distutils_setup(

--- a/arbotix_python/src/arbotix_python/diff_controller.py
+++ b/arbotix_python/src/arbotix_python/diff_controller.py
@@ -37,8 +37,8 @@ from nav_msgs.msg import Odometry
 from diagnostic_msgs.msg import *
 from tf.broadcaster import TransformBroadcaster
 
-from ax12 import *
-from controllers import *
+from arbotix_python.ax12 import *
+from arbotix_python.controllers import *
 from struct import unpack
 
 class DiffController(Controller):

--- a/arbotix_python/src/arbotix_python/follow_controller.py
+++ b/arbotix_python/src/arbotix_python/follow_controller.py
@@ -33,8 +33,8 @@ from control_msgs.msg import FollowJointTrajectoryAction
 from trajectory_msgs.msg import JointTrajectory
 from diagnostic_msgs.msg import *
 
-from ax12 import *
-from controllers import *
+from arbotix_python.ax12 import *
+from arbotix_python.controllers import *
 
 class FollowController(Controller):
     """ A controller for joint chains, exposing a FollowJointTrajectory action. """

--- a/arbotix_python/src/arbotix_python/linear_controller.py
+++ b/arbotix_python/src/arbotix_python/linear_controller.py
@@ -29,8 +29,8 @@
 
 import rospy, actionlib
 
-from joints import *
-from controllers import *
+from arbotix_python.joints import *
+from arbotix_python.controllers import *
 from std_msgs.msg import Float64
 from diagnostic_msgs.msg import *
 from std_srvs.srv import *
@@ -172,7 +172,7 @@ class LinearControllerAbsolute(Controller):
                         self.last_reading = self.getPosition()
                         self.joint.setCurrentFeedback(self.last_reading)
                     except Exception as e:
-                        print "linear error: ", e
+                        print("linear error: ", e)
                 # update movement
                 output = self.joint.interpolate(1.0/self.delta.to_sec())
                 if self.last != output and not self.fake: 

--- a/arbotix_python/src/arbotix_python/servo_controller.py
+++ b/arbotix_python/src/arbotix_python/servo_controller.py
@@ -35,8 +35,8 @@ from std_msgs.msg import Float64
 from arbotix_msgs.srv import *
 from diagnostic_msgs.msg import *
 
-from ax12 import *
-from joints import *
+from arbotix_python.ax12 import *
+from arbotix_python.joints import *
 
 class DynamixelServo(Joint):
 
@@ -351,7 +351,7 @@ class HobbyServo(Joint):
             self.desired = req.data
 
 
-from controllers import *
+from arbotix_python.controllers import *
 
 class ServoController(Controller):
 


### PR DESCRIPTION
Mike, as you already mentioned shebang problem, yesterday I had an error message because of python shebang in bin/arbotix_driver. Fresh install of Ubuntu server 20.04 + ROS NN on a raspberry pi 4 8GB RAM. Changing the above shebang to python3 works. Maybe change all shebangs to python3 now?

During installation I recognized another issue with a rosdep dependency about python-serial, changing to python3-serial works.